### PR TITLE
Added isBigInteger static method

### DIFF
--- a/lib/bigi.js
+++ b/lib/bigi.js
@@ -14,6 +14,12 @@ function BigInteger(a, b, c) {
 
 var proto = BigInteger.prototype
 
+// duck-typed isBigInteger
+proto.__bigi = require('../package.json').version
+BigInteger.isBigInteger = function (obj, check_ver) {
+  return obj && obj.__bigi && (!check_ver || obj.__bigi === proto.__bigi)
+}
+
 // Bits per digit
 var dbits
 


### PR DESCRIPTION
Uses duck-typing with a special property to detect if its a `bigi` instance and optionally match the version number.

This is needed because `instanceof` checks doesn't work when multiple `bigi` libraries are used, which is quite common with npm.

Specifically, I had an issue due to my application specifying `bigi` as its own dependency and creating `BigInteger`s with that, while the `ecdsa` library relies on an `instanceof` check with its own `bigi` dependency to verify that a provided argument is an `BigInteger`. Following up with a patch on `ecdsa` to use the new method.
