### PR TITLE
Add `byteLength` method

### DIFF
--- a/lib/bigi.js
+++ b/lib/bigi.js
@@ -275,6 +275,11 @@ function bnBitLength() {
   return this.DB * (this.t - 1) + nbits(this[this.t - 1] ^ (this.s & this.DM))
 }
 
+// (public) return the number of bytes in "this"
+function bnByteLength() {
+  return this.bitLength() >> 3
+}
+
 // (protected) r = this << n*DB
 function bnpDLShiftTo(n, r) {
   var i
@@ -652,6 +657,7 @@ proto.negate = bnNegate
 proto.abs = bnAbs
 proto.compareTo = bnCompareTo
 proto.bitLength = bnBitLength
+proto.byteLength = bnByteLength
 proto.mod = bnMod
 proto.modPowInt = bnModPowInt
 

--- a/test/bigi.js
+++ b/test/bigi.js
@@ -48,6 +48,20 @@ describe('BigInteger', function () {
     assert.equal(new BigInteger('8023456789', 16).bitLength(), 40)
   })
 
+  it('should return proper byteLength', function () {
+    assert.equal(new BigInteger('0').byteLength(), 0)
+    assert.equal(new BigInteger('1', 16).byteLength(), 0)
+    assert.equal(new BigInteger('2', 16).byteLength(), 0)
+    assert.equal(new BigInteger('3', 16).byteLength(), 0)
+    assert.equal(new BigInteger('4', 16).byteLength(), 0)
+    assert.equal(new BigInteger('8', 16).byteLength(), 0)
+    assert.equal(new BigInteger('10', 16).byteLength(), 0)
+    assert.equal(new BigInteger('100', 16).byteLength(), 1)
+    assert.equal(new BigInteger('123456', 16).byteLength(), 2)
+    assert.equal(new BigInteger('123456789', 16).byteLength(), 4)
+    assert.equal(new BigInteger('8023456789', 16).byteLength(), 5)
+  })
+
   it('should add numbers', function () {
     assert.equal(new BigInteger('14').add(new BigInteger('26')).toString(16), '28')
     var k = new BigInteger('1234', 16)


### PR DESCRIPTION
This patch adds a new method: `byteLength`, which returns the number of bytes in the current number (`this`). This not only compliments `bitLength` but also aids modules that may want to support both bn (which has this method) and bigi.
- [x] Add to docs when merged (cryptocoinjs/cryptocoinjs.com#4)
