### PR TITLE
Add `isProbablePrime` method

### DIFF
--- a/lib/bigi.js
+++ b/lib/bigi.js
@@ -1383,6 +1383,72 @@ function bnModInverse(m) {
   else return d
 }
 
+var lowprimes = [
+  2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71,
+  73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151,
+  157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233,
+  239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311, 313, 317,
+  331, 337, 347, 349, 353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419,
+  421, 431, 433, 439, 443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503,
+  509, 521, 523, 541, 547, 557, 563, 569, 571, 577, 587, 593, 599, 601, 607,
+  613, 617, 619, 631, 641, 643, 647, 653, 659, 661, 673, 677, 683, 691, 701,
+  709, 719, 727, 733, 739, 743, 751, 757, 761, 769, 773, 787, 797, 809, 811,
+  821, 823, 827, 829, 839, 853, 857, 859, 863, 877, 881, 883, 887, 907, 911,
+  919, 929, 937, 941, 947, 953, 967, 971, 977, 983, 991, 997
+]
+
+var lplim = (1 << 26) / lowprimes[lowprimes.length - 1]
+
+// (public) test primality with certainty >= 1-.5^t
+function bnIsProbablePrime(t) {
+  var i, x = this.abs()
+  if (x.t == 1 && x[0] <= lowprimes[lowprimes.length - 1]) {
+    for (i = 0; i < lowprimes.length; ++i)
+      if (x[0] == lowprimes[i]) return true
+    return false
+  }
+  if (x.isEven()) return false
+  i = 1
+  while (i < lowprimes.length) {
+    var m = lowprimes[i],
+      j = i + 1
+    while (j < lowprimes.length && m < lplim) m *= lowprimes[j++]
+    m = x.modInt(m)
+    while (i < j) if (m % lowprimes[i++] == 0) return false
+  }
+  return x.millerRabin(t)
+}
+
+// (protected) true if probably prime (HAC 4.24, Miller-Rabin)
+function bnpMillerRabin(t) {
+  var n1 = this.subtract(BigInteger.ONE)
+  var k = n1.getLowestSetBit()
+  if (k <= 0) return false
+  var r = n1.shiftRight(k)
+  t = (t + 1) >> 1
+  if (t > lowprimes.length) t = lowprimes.length
+  var a = new BigInteger(null)
+  var j, bases = []
+  for (var i = 0; i < t; ++i) {
+    for (;;) {
+      j = lowprimes[Math.floor(Math.random() * lowprimes.length)]
+      if (bases.indexOf(j) == -1) break
+    }
+    bases.push(j)
+    a.fromInt(j)
+    var y = a.modPow(r, this)
+    if (y.compareTo(BigInteger.ONE) != 0 && y.compareTo(n1) != 0) {
+      var j = 1
+      while (j++ < k && y.compareTo(n1) != 0) {
+        y = y.modPowInt(2, this)
+        if (y.compareTo(BigInteger.ONE) == 0) return false
+      }
+      if (y.compareTo(n1) != 0) return false
+    }
+  }
+  return true
+}
+
 // protected
 proto.chunkSize = bnpChunkSize
 proto.toRadix = bnpToRadix
@@ -1396,6 +1462,7 @@ proto.dAddOffset = bnpDAddOffset
 proto.multiplyLowerTo = bnpMultiplyLowerTo
 proto.multiplyUpperTo = bnpMultiplyUpperTo
 proto.modInt = bnpModInt
+proto.millerRabin = bnpMillerRabin
 
 // public
 proto.clone = bnClone
@@ -1430,6 +1497,7 @@ proto.modPow = bnModPow
 proto.modInverse = bnModInverse
 proto.pow = bnPow
 proto.gcd = bnGCD
+proto.isProbablePrime = bnIsProbablePrime
 
 // JSBN-specific extension
 proto.square = bnSquare

--- a/test/bigi.js
+++ b/test/bigi.js
@@ -186,4 +186,14 @@ describe('BigInteger', function () {
     var b = a.modInverse(p192)
     assert.equal(a.multiply(b).mod(p192).toString(16), '1')
   })
+
+  it('should calculate if probable prime', function () {
+    // not prime
+    var a = new BigInteger('561')
+    assert.ok(!a.isProbablePrime())
+
+    // not prime, but `true` returned anyways because test is probabilistic
+    var p = new BigInteger('25326001')
+    assert.ok(p.isProbablePrime())
+  })
 })


### PR DESCRIPTION
This method [is used in `bnpFromNumber`](https://github.com/cryptocoinjs/bigi/blob/a4deffb3ec839025c5360abcdacfa5793c77a419/lib/bigi.js#L765) but doesn't actually exist. This is a port of the missing method from openpgpjs.
