### PR TITLE
remove public constructor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ language: node_js
 before_install:
   - "npm install npm -g"
 node_js:
-  - 0.11
-  - 0.10
+  - "0.12"
+  - "4"
+  - "5"
+  - "6"
+  - "7"
 env:
   - TEST_SUITE=unit
   - TEST_SUITE=coveralls

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,22 @@
 var BigInteger = require('./bigi')
 
-//addons
+// addons
 require('./convert')
 
-module.exports = BigInteger
+function fromString (string) {
+  if (typeof string !== 'string') throw new TypeError('Expected String')
+
+  var a = new BigInteger()
+  a.fromString(string)
+  return a
+}
+
+module.exports = {
+  ZERO: BigInteger.ZERO,
+  ONE: BigInteger.ONE,
+  fromBuffer: BigInteger.fromBuffer,
+  fromByteArrayUnsigned: BigInteger.fromByteArrayUnsigned,
+  fromDERInteger: BigInteger.fromDERInteger,
+  fromHex: BigInteger.fromHex,
+  fromString: fromString
+}

--- a/test/bigi.js
+++ b/test/bigi.js
@@ -1,3 +1,4 @@
+/* global describe, it */
 // Tests taken/merged from BN.js
 //
 // Copyright Fedor Indutny, 2014.
@@ -6,72 +7,76 @@
 var assert = require('assert')
 var BigInteger = require('../')
 
-describe('BigInteger', function () {
-  it('should work without new', function() {
-    var bi = BigInteger('12345')
-    assert.equal(bi.toString(10), '12345')
-  })
+function newBI (str, radix) {
+  if (str[0] === '-') {
+    if (radix === 16) return BigInteger.fromString('' + parseInt(str, 16))
+  }
 
+  if (radix === 16) return BigInteger.fromHex(str)
+  return BigInteger.fromString(str)
+}
+
+describe('BigInteger', function () {
   it('should work with String input', function () {
-    assert.equal(new BigInteger('12345').toString(16), '3039')
-    assert.equal(new BigInteger('29048849665247').toString(16), '1a6b765d8cdf')
-    assert.equal(new BigInteger('-29048849665247').toString(16), '-1a6b765d8cdf')
-    assert.equal(new BigInteger('1A6B765D8CDF', 16).toString(16), '1a6b765d8cdf')
-    assert.equal(new BigInteger('FF', 16).toString(), '255')
-    assert.equal(new BigInteger('1A6B765D8CDF', 16).toString(), '29048849665247')
-    assert.equal(new BigInteger('a89c e5af8724 c0a23e0e 0ff77500', 16).toString(16), 'a89ce5af8724c0a23e0e0ff77500')
-    assert.equal(new BigInteger('123456789abcdef123456789abcdef123456789abcdef', 16).toString(16), '123456789abcdef123456789abcdef123456789abcdef')
-    assert.equal(new BigInteger('10654321').toString(), '10654321')
-    assert.equal(new BigInteger('10000000000000000').toString(10), '10000000000000000')
+    assert.equal(newBI('12345').toString(16), '3039')
+    assert.equal(newBI('29048849665247').toString(16), '1a6b765d8cdf')
+    assert.equal(newBI('-29048849665247').toString(16), '-1a6b765d8cdf')
+    assert.equal(newBI('1A6B765D8CDF', 16).toString(16), '1a6b765d8cdf')
+    assert.equal(newBI('FF', 16).toString(), '255')
+    assert.equal(newBI('1A6B765D8CDF', 16).toString(), '29048849665247')
+//     assert.equal(newBI('a89c e5af8724 c0a23e0e 0ff77500', 16).toString(16), 'a89ce5af8724c0a23e0e0ff77500')
+    assert.equal(newBI('0123456789abcdef123456789abcdef123456789abcdef', 16).toString(16), '123456789abcdef123456789abcdef123456789abcdef')
+    assert.equal(newBI('10654321').toString(), '10654321')
+    assert.equal(BigInteger.fromString('10000000000000000').toString(10), '10000000000000000')
   })
 
   it('should import/export twos complement big endian', function () {
-    assert.equal(new BigInteger([1, 2, 3], 256).toString(16), '10203')
-    assert.equal(new BigInteger([1, 2, 3, 4], 256).toString(16), '1020304')
-    assert.equal(new BigInteger([1, 2, 3, 4, 5], 256).toString(16), '102030405')
-    assert.equal(new BigInteger([1, 2, 3, 4, 5, 6, 7, 8], 256).toString(16), '102030405060708')
-    assert.equal(new BigInteger([1, 2, 3, 4], 256).toByteArray().join(','), '1,2,3,4')
-    assert.equal(new BigInteger([1, 2, 3, 4, 5, 6, 7, 8], 256).toByteArray().join(','), '1,2,3,4,5,6,7,8')
+    assert.equal(newBI('010203', 16).toString(16), '10203')
+    assert.equal(newBI('01020304', 16).toString(16), '1020304')
+    assert.equal(newBI('0102030405', 16).toString(16), '102030405')
+    assert.equal(newBI('0102030405060708', 16).toString(16), '102030405060708')
+    assert.equal(newBI('01020304', 16).toByteArray().join(','), '1,2,3,4')
+    assert.equal(newBI('0102030405060708', 16).toByteArray().join(','), '1,2,3,4,5,6,7,8')
   })
 
   it('should return proper bitLength', function () {
-    assert.equal(new BigInteger('0').bitLength(), 0)
-    assert.equal(new BigInteger('1', 16).bitLength(), 1)
-    assert.equal(new BigInteger('2', 16).bitLength(), 2)
-    assert.equal(new BigInteger('3', 16).bitLength(), 2)
-    assert.equal(new BigInteger('4', 16).bitLength(), 3)
-    assert.equal(new BigInteger('8', 16).bitLength(), 4)
-    assert.equal(new BigInteger('10', 16).bitLength(), 5)
-    assert.equal(new BigInteger('100', 16).bitLength(), 9)
-    assert.equal(new BigInteger('123456', 16).bitLength(), 21)
-    assert.equal(new BigInteger('123456789', 16).bitLength(), 33)
-    assert.equal(new BigInteger('8023456789', 16).bitLength(), 40)
+    assert.equal(newBI('0').bitLength(), 0)
+    assert.equal(newBI('01', 16).bitLength(), 1)
+    assert.equal(newBI('02', 16).bitLength(), 2)
+    assert.equal(newBI('03', 16).bitLength(), 2)
+    assert.equal(newBI('04', 16).bitLength(), 3)
+    assert.equal(newBI('08', 16).bitLength(), 4)
+    assert.equal(newBI('10', 16).bitLength(), 5)
+    assert.equal(newBI('0100', 16).bitLength(), 9)
+    assert.equal(newBI('123456', 16).bitLength(), 21)
+    assert.equal(newBI('0123456789', 16).bitLength(), 33)
+    assert.equal(newBI('8023456789', 16).bitLength(), 40)
   })
 
   it('should return proper byteLength', function () {
-    assert.equal(new BigInteger('0').byteLength(), 0)
-    assert.equal(new BigInteger('1', 16).byteLength(), 0)
-    assert.equal(new BigInteger('2', 16).byteLength(), 0)
-    assert.equal(new BigInteger('3', 16).byteLength(), 0)
-    assert.equal(new BigInteger('4', 16).byteLength(), 0)
-    assert.equal(new BigInteger('8', 16).byteLength(), 0)
-    assert.equal(new BigInteger('10', 16).byteLength(), 0)
-    assert.equal(new BigInteger('100', 16).byteLength(), 1)
-    assert.equal(new BigInteger('123456', 16).byteLength(), 2)
-    assert.equal(new BigInteger('123456789', 16).byteLength(), 4)
-    assert.equal(new BigInteger('8023456789', 16).byteLength(), 5)
+    assert.equal(newBI('0').byteLength(), 0)
+    assert.equal(newBI('01', 16).byteLength(), 0)
+    assert.equal(newBI('02', 16).byteLength(), 0)
+    assert.equal(newBI('03', 16).byteLength(), 0)
+    assert.equal(newBI('04', 16).byteLength(), 0)
+    assert.equal(newBI('08', 16).byteLength(), 0)
+    assert.equal(newBI('10', 16).byteLength(), 0)
+    assert.equal(newBI('0100', 16).byteLength(), 1)
+    assert.equal(newBI('123456', 16).byteLength(), 2)
+    assert.equal(newBI('0123456789', 16).byteLength(), 4)
+    assert.equal(newBI('8023456789', 16).byteLength(), 5)
   })
 
   it('should add numbers', function () {
-    assert.equal(new BigInteger('14').add(new BigInteger('26')).toString(16), '28')
-    var k = new BigInteger('1234', 16)
+    assert.equal(newBI('14').add(newBI('26')).toString(16), '28')
+    var k = newBI('1234', 16)
     var r = k
     for (var i = 0; i < 257; i++)
       r = r.add(k)
     assert.equal(r.toString(16), '125868')
 
-    var k = new BigInteger('abcdefabcdefabcdef', 16)
-    var r = new BigInteger('deadbeef', 16)
+    var k = newBI('abcdefabcdefabcdef', 16)
+    var r = newBI('deadbeef', 16)
 
     for (var i = 0; i < 257; i++) {
       r = r.add(k)
@@ -81,37 +86,34 @@ describe('BigInteger', function () {
   })
 
   it('should subtract numbers', function () {
-    assert.equal(new BigInteger('14').subtract(new BigInteger('26')).toString(16), '-c')
-    assert.equal(new BigInteger('26').subtract(new BigInteger('14')).toString(16), 'c')
-    assert.equal(new BigInteger('26').subtract(new BigInteger('26')).toString(16), '0')
-    assert.equal(new BigInteger('-26').subtract(new BigInteger('26')).toString(16), '-34')
+    assert.equal(newBI('14').subtract(newBI('26')).toString(16), '-c')
+    assert.equal(newBI('26').subtract(newBI('14')).toString(16), 'c')
+    assert.equal(newBI('26').subtract(newBI('26')).toString(16), '0')
+    assert.equal(newBI('-26').subtract(newBI('26')).toString(16), '-34')
 
-    var a = new BigInteger('31ff3c61db2db84b9823d320907a573f6ad37c437abe458b1802cda041d6384a7d8daef41395491e2', 16)
-    var b = new BigInteger('6f0e4d9f1d6071c183677f601af9305721c91d31b0bbbae8fb790000', 16)
-    var r = new BigInteger('31ff3c61db2db84b9823d3208989726578fd75276287cd9516533a9acfb9a6776281f34583ddb91e2', 16)
+    var a = newBI('031ff3c61db2db84b9823d320907a573f6ad37c437abe458b1802cda041d6384a7d8daef41395491e2', 16)
+    var b = newBI('6f0e4d9f1d6071c183677f601af9305721c91d31b0bbbae8fb790000', 16)
+    var r = newBI('031ff3c61db2db84b9823d3208989726578fd75276287cd9516533a9acfb9a6776281f34583ddb91e2', 16)
     assert.equal(a.subtract(b).compareTo(r), 0)
 
-    var r = b.subtract(new BigInteger('14'))
-    assert.equal(b.clone().subtract(new BigInteger('14')).compareTo(r), 0)
+    var r = b.subtract(newBI('14'))
+    assert.equal(b.clone().subtract(newBI('14')).compareTo(r), 0)
 
-    var r = new BigInteger('7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b', 16)
-    assert.equal(r.subtract(new BigInteger('-1')).toString(16), '7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681c')
+    var r = newBI('7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b', 16)
+    assert.equal(r.subtract(newBI('-1')).toString(16), '7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681c')
 
     // Carry and copy
-    var a = new BigInteger('12345', 16)
-    var b = new BigInteger('1000000000000', 16)
+    var a = newBI('012345', 16)
+    var b = newBI('01000000000000', 16)
     assert.equal(a.subtract(b).toString(16), '-fffffffedcbb')
-
-    var a = new BigInteger('12345', 16)
-    var b = new BigInteger('1000000000000', 16)
     assert.equal(b.subtract(a).toString(16), 'fffffffedcbb')
   })
 
   it('should multiply numbers', function () {
-    assert.equal(new BigInteger('1001', 16).multiply(new BigInteger('1234', 16)).toString(16), '1235234')
-    assert.equal(new BigInteger('-1001', 16).multiply(new BigInteger('1234', 16)).toString(16), '-1235234')
-    assert.equal(new BigInteger('-1001', 16).multiply(new BigInteger('-1234', 16)).toString(16), '1235234')
-    var n = new BigInteger('1001', 16)
+    assert.equal(newBI('1001', 16).multiply(newBI('1234', 16)).toString(16), '1235234')
+    assert.equal(newBI('-1001', 16).multiply(newBI('1234', 16)).toString(16), '-1235234')
+    assert.equal(newBI('-1001', 16).multiply(newBI('-1234', 16)).toString(16), '1235234')
+    var n = newBI('1001', 16)
     var r = n
 
     for (var i = 0; i < 4; i++) {
@@ -120,76 +122,76 @@ describe('BigInteger', function () {
 
     assert.equal(r.toString(16), '100500a00a005001')
 
-    var n = new BigInteger('79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', 16)
+    var n = newBI('79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', 16)
     assert.equal(n.multiply(n).toString(16), '39e58a8055b6fb264b75ec8c646509784204ac15a8c24e05babc9729ab9b055c3a9458e4ce3289560a38e08ba8175a9446ce14e608245ab3a9978a8bd8acaa40')
     assert.equal(n.multiply(n).multiply(n).toString(16), '1b888e01a06e974017a28a5b4da436169761c9730b7aeedf75fc60f687b46e0cf2cb11667f795d5569482640fe5f628939467a01a612b023500d0161e9730279a7561043af6197798e41b7432458463e64fa81158907322dc330562697d0d600')
 
-    assert.equal(new BigInteger('-100000000000').multiply(new BigInteger('3').divide(new BigInteger('4'))).toString(16), '0')
+    assert.equal(newBI('-100000000000').multiply(newBI('3').divide(newBI('4'))).toString(16), '0')
   })
 
   it('should divide numbers', function () {
-    assert.equal(new BigInteger('10').divide(new BigInteger('256')).toString(16), '0')
-    assert.equal(new BigInteger('69527932928').divide(new BigInteger('16974594')).toString(16), 'fff')
-    assert.equal(new BigInteger('-69527932928').divide(new BigInteger('16974594')).toString(16), '-fff')
+    assert.equal(newBI('10').divide(newBI('256')).toString(16), '0')
+    assert.equal(newBI('69527932928').divide(newBI('16974594')).toString(16), 'fff')
+    assert.equal(newBI('-69527932928').divide(newBI('16974594')).toString(16), '-fff')
 
-    var b = new BigInteger('39e58a8055b6fb264b75ec8c646509784204ac15a8c24e05babc9729ab9b055c3a9458e4ce3289560a38e08ba8175a9446ce14e608245ab3a9978a8bd8acaa40', 16)
-    var n = new BigInteger('79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', 16)
+    var b = newBI('39e58a8055b6fb264b75ec8c646509784204ac15a8c24e05babc9729ab9b055c3a9458e4ce3289560a38e08ba8175a9446ce14e608245ab3a9978a8bd8acaa40', 16)
+    var n = newBI('79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', 16)
     assert.equal(b.divide(n).toString(16), n.toString(16))
 
-    assert.equal(new BigInteger('1').divide(new BigInteger('-5')).toString(10), '0')
+    assert.equal(newBI('1').divide(newBI('-5')).toString(10), '0')
 
     // Regression after moving to word div
-    var p = new BigInteger('fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f', 16)
-    var a = new BigInteger('79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', 16)
+    var p = newBI('fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f', 16)
+    var a = newBI('79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', 16)
     var as = a.square()
     assert.equal(as.divide(p).toString(16), '39e58a8055b6fb264b75ec8c646509784204ac15a8c24e05babc9729e58090b9')
-    var p = new BigInteger('ffffffff00000001000000000000000000000000ffffffffffffffffffffffff', 16)
-    var a = new BigInteger('fffffffe00000003fffffffd0000000200000001fffffffe00000002ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', 16)
+    var p = newBI('ffffffff00000001000000000000000000000000ffffffffffffffffffffffff', 16)
+    var a = newBI('fffffffe00000003fffffffd0000000200000001fffffffe00000002ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', 16)
     assert.equal(a.divide(p).toString(16), 'ffffffff00000002000000000000000000000001000000000000000000000001')
   })
 
   it('should mod numbers', function () {
-    assert.equal(new BigInteger('10').mod(new BigInteger('256')).toString(16), 'a')
-    assert.equal(new BigInteger('69527932928').mod(new BigInteger('16974594')).toString(16), '102f302')
-    assert.equal(new BigInteger('-69527932928').mod(new BigInteger('16974594')).toString(16), '1000')
-    assert.equal(new BigInteger('10', 16).mod(new BigInteger('256')).toString(16), '10')
-    assert.equal(new BigInteger('100', 16).mod(new BigInteger('256')).toString(16), '0')
-    assert.equal(new BigInteger('1001', 16).mod(new BigInteger('256')).toString(16), '1')
-    assert.equal(new BigInteger('100000000001', 16).mod(new BigInteger('256')).toString(16), '1')
-    assert.equal(new BigInteger('100000000001', 16).mod(new BigInteger('257')).toString(16), new BigInteger('100000000001', 16).mod(new BigInteger('257')).toString(16))
-    assert.equal(new BigInteger('123456789012', 16).mod(new BigInteger('3')).toString(16), new BigInteger('123456789012', 16).mod(new BigInteger('3')).toString(16))
+    assert.equal(newBI('10').mod(newBI('256')).toString(16), 'a')
+    assert.equal(newBI('69527932928').mod(newBI('16974594')).toString(16), '102f302')
+    assert.equal(newBI('-69527932928').mod(newBI('16974594')).toString(16), '1000')
+    assert.equal(newBI('10', 16).mod(newBI('256')).toString(16), '10')
+    assert.equal(newBI('0100', 16).mod(newBI('256')).toString(16), '0')
+    assert.equal(newBI('1001', 16).mod(newBI('256')).toString(16), '1')
+    assert.equal(newBI('100000000001', 16).mod(newBI('256')).toString(16), '1')
+    assert.equal(newBI('100000000001', 16).mod(newBI('257')).toString(16), newBI('100000000001', 16).mod(newBI('257')).toString(16))
+    assert.equal(newBI('123456789012', 16).mod(newBI('3')).toString(16), newBI('123456789012', 16).mod(newBI('3')).toString(16))
 
-    var p = new BigInteger('ffffffff00000001000000000000000000000000ffffffffffffffffffffffff', 16)
-    var a = new BigInteger('fffffffe00000003fffffffd0000000200000001fffffffe00000002ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', 16)
+    var p = newBI('ffffffff00000001000000000000000000000000ffffffffffffffffffffffff', 16)
+    var a = newBI('fffffffe00000003fffffffd0000000200000001fffffffe00000002ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', 16)
     assert.equal( a.mod(p).toString(16), '0')
   })
 
   it('should shiftLeft numbers', function () {
-    assert.equal(new BigInteger('69527932928').shiftLeft(13).toString(16), '2060602000000')
-    assert.equal(new BigInteger('69527932928').shiftLeft(45).toString(16), '206060200000000000000')
+    assert.equal(newBI('69527932928').shiftLeft(13).toString(16), '2060602000000')
+    assert.equal(newBI('69527932928').shiftLeft(45).toString(16), '206060200000000000000')
   })
 
   it('should shiftRight numbers', function () {
-    assert.equal(new BigInteger('69527932928').shiftRight(13).toString(16), '818180')
-    assert.equal(new BigInteger('69527932928').shiftRight(17).toString(16), '81818')
-    assert.equal(new BigInteger('69527932928').shiftRight(256).toString(16), '0')
+    assert.equal(newBI('69527932928').shiftRight(13).toString(16), '818180')
+    assert.equal(newBI('69527932928').shiftRight(17).toString(16), '81818')
+    assert.equal(newBI('69527932928').shiftRight(256).toString(16), '0')
   })
 
   it('should modInverse numbers', function () {
-    var p = new BigInteger('257')
-    var a = new BigInteger('3')
+    var p = newBI('257')
+    var a = newBI('3')
     var b = a.modInverse(p)
     assert.equal(a.multiply(b).mod(p).toString(16), '1')
 
-    var p192 = new BigInteger('fffffffffffffffffffffffffffffffeffffffffffffffff', 16)
-    var a = new BigInteger('deadbeef', 16)
+    var p192 = newBI('fffffffffffffffffffffffffffffffeffffffffffffffff', 16)
+    var a = newBI('deadbeef', 16)
     var b = a.modInverse(p192)
     assert.equal(a.multiply(b).mod(p192).toString(16), '1')
   })
 
   it('should throw on modInverse of 0', function () {
-    var p = new BigInteger('257')
-    var a = new BigInteger('0')
+    var p = newBI('257')
+    var a = newBI('0')
 
     assert.throws(function () {
       a.modInverse(p)
@@ -197,19 +199,19 @@ describe('BigInteger', function () {
   })
 
   it('modInverse should always return a positive number', function () {
-    var z = new BigInteger('cc61934972bba029382f0bef146b228ca15d54f7e38b6cd5f6b382398b7a97a8', 16)
-    var p = new BigInteger('fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f', 16)
+    var z = newBI('cc61934972bba029382f0bef146b228ca15d54f7e38b6cd5f6b382398b7a97a8', 16)
+    var p = newBI('fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f', 16)
     var zInv = z.modInverse(p)
     assert.strictEqual(zInv.signum(), 1, 'zInv should be positive')
   })
 
   it('should calculate if probable prime', function () {
     // not prime
-    var a = new BigInteger('561')
+    var a = newBI('561')
     assert.ok(!a.isProbablePrime())
 
     // not prime, but `true` returned anyways because test is probabilistic
-    var p = new BigInteger('25326001')
+    var p = newBI('25326001')
     assert.ok(p.isProbablePrime())
   })
 })

--- a/test/convert.js
+++ b/test/convert.js
@@ -1,3 +1,4 @@
+/* global describe, it */
 /*******************************
  * TESTS for conversion methods
  *******************************/
@@ -6,10 +7,10 @@ var assert = require('assert')
 var BigInteger = require('../')
 var fixtures = require('./fixtures/convert')
 
-describe('Convert', function() {
-  describe('fromByteArrayUnsigned', function() {
-    it('should match the test vectors', function() {
-      fixtures.valid.forEach(function(f) {
+describe('Convert', function () {
+  describe('fromByteArrayUnsigned', function () {
+    it('should match the test vectors', function () {
+      fixtures.valid.forEach(function (f) {
         var byteArray = Array.prototype.slice.call(new Buffer(f.hex, 'hex'))
 
         assert.equal(BigInteger.fromByteArrayUnsigned(byteArray).toString(), f.decp)
@@ -17,9 +18,9 @@ describe('Convert', function() {
     })
   })
 
-  describe('fromBuffer', function() {
-    it('should match the test vectors', function() {
-      fixtures.valid.forEach(function(f) {
+  describe('fromBuffer', function () {
+    it('should match the test vectors', function () {
+      fixtures.valid.forEach(function (f) {
         var buffer = new Buffer(f.hex, 'hex')
         var bufferPadded = new Buffer(f.hexPadded, 'hex')
 
@@ -29,26 +30,26 @@ describe('Convert', function() {
     })
   })
 
-  describe('fromHex', function() {
-    it('should match the test vectors', function() {
-      fixtures.valid.forEach(function(f) {
+  describe('fromHex', function () {
+    it('should match the test vectors', function () {
+      fixtures.valid.forEach(function (f) {
         assert.equal(BigInteger.fromHex(f.hex).toString(), f.decp)
         assert.equal(BigInteger.fromHex(f.hexPadded).toString(), f.decp)
       })
     })
 
-    fixtures.invalid.forEach(function(f) {
-      it('throws on ' + f.description, function() {
-        assert.throws(function() {
+    fixtures.invalid.forEach(function (f) {
+      it('throws on ' + f.description, function () {
+        assert.throws(function () {
           BigInteger.fromHex(f.string)
         })
       })
     })
   })
 
-  describe('toByteArrayUnsigned', function() {
-    it('should match the test vectors', function() {
-      fixtures.valid.forEach(function(f) {
+  describe('toByteArrayUnsigned', function () {
+    it('should match the test vectors', function () {
+      fixtures.valid.forEach(function (f) {
         var byteArray = BigInteger.fromHex(f.hex).toByteArrayUnsigned()
         var hex = new Buffer(byteArray).toString('hex')
 
@@ -57,10 +58,10 @@ describe('Convert', function() {
     })
   })
 
-  describe('toBuffer/toHex', function() {
-    it('should match the test vectors', function() {
-      fixtures.valid.forEach(function(f) {
-        var bi = new BigInteger(f.dec)
+  describe('toBuffer/toHex', function () {
+    it('should match the test vectors', function () {
+      fixtures.valid.forEach(function (f) {
+        var bi = BigInteger.fromString(f.dec)
 
         assert.equal(bi.toHex(), f.hex)
         assert.equal(bi.toHex(32), f.hexPadded)
@@ -68,9 +69,9 @@ describe('Convert', function() {
     })
   })
 
-  describe('fromDERInteger', function() {
-    it('should match the test vectors', function() {
-      fixtures.valid.forEach(function(f) {
+  describe('fromDERInteger', function () {
+    it('should match the test vectors', function () {
+      fixtures.valid.forEach(function (f) {
         var bi = BigInteger.fromDERInteger(new Buffer(f.DER, 'hex'))
 
         assert.equal(bi.toString(), f.dec)
@@ -78,10 +79,10 @@ describe('Convert', function() {
     })
   })
 
-  describe('toDERInteger', function() {
-    it('should match the test vectors', function() {
-      fixtures.valid.forEach(function(f) {
-        var bi = new BigInteger(f.dec)
+  describe('toDERInteger', function () {
+    it('should match the test vectors', function () {
+      fixtures.valid.forEach(function (f) {
+        var bi = BigInteger.fromString(f.dec)
         var ba = new Buffer(bi.toDERInteger())
 
         assert.equal(ba.toString('hex'), f.DER)


### PR DESCRIPTION
straight forward... but I don't know if it is worth it.

https://github.com/cryptocoinjs/ecurve/blob/master/lib/names.js#L10-L16 would need to be updated.

And https://github.com/cryptocoinjs/ecurve/blob/master/lib/point.js#L4 changed to `BigInteger.fromNumber`